### PR TITLE
xva build: Accept a setup script URL

### DIFF
--- a/jenkins/jobs/builds/build-devstack-xva-online-stage1.sh
+++ b/jenkins/jobs/builds/build-devstack-xva-online-stage1.sh
@@ -4,6 +4,7 @@ set -eux
 
 XENSERVERHOST=$1
 XENSERVERPASSWORD=$2
+SETUPSCRIPT_URL="$3"
 
 TEMPKEYFILE=$(mktemp)
 
@@ -11,7 +12,7 @@ TEMPKEYFILE=$(mktemp)
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y install xcp-xe stunnel sshpass
 
 rm -f install-devstack-xen.sh || true
-wget https://raw.github.com/citrix-openstack/qa/master/install-devstack-xen.sh
+wget -qO install-devstack-xen.sh "$SETUPSCRIPT_URL"
 chmod 755 install-devstack-xen.sh
 rm -f $TEMPKEYFILE
 ssh-keygen -t rsa -N "" -f $TEMPKEYFILE

--- a/jenkins/jobs/xva-build.sh
+++ b/jenkins/jobs/xva-build.sh
@@ -21,6 +21,7 @@ function parse_parameters() {
     shift || print_usage_and_die "No xenserver specified"
     XenServerPassword="$1"
     shift || print_usage_and_die "No xenserver_password specified"
+    SETUPSCRIPT_URL="${1:-"https://raw.github.com/citrix-openstack/qa/master/install-devstack-xen.sh"}"
     set -u
 }
 
@@ -33,7 +34,7 @@ echo "Worker: $WORKER"
 
 echo "Building Devstack XVA" | log_info
 run_bash_script_on "$WORKER" \
-    "$THISDIR/builds/build-devstack-xva-online-stage1.sh" "$HOST" "$XenServerPassword"
+    "$THISDIR/builds/build-devstack-xva-online-stage1.sh" "$HOST" "$XenServerPassword" "$SETUPSCRIPT_URL"
 run_bash_script_on "$WORKER" \
     "$THISDIR/builds/build-devstack-xva-online-stage2.sh" "$HOST" "$XenServerPassword"
 


### PR DESCRIPTION
This way we can use a pre-generated setup script to create an xva from a
citrix build.
