### PR TITLE
Unattended apt for xenserver-core build job

### DIFF
--- a/jenkins/jobs/build-xenserver-core-ubuntu.sh
+++ b/jenkins/jobs/build-xenserver-core-ubuntu.sh
@@ -28,9 +28,14 @@ SLAVE_IP=$(cat $XSLIB/start-slave.sh | "$REMOTELIB/bash.sh" "root@$XENSERVERNAME
 "$REMOTELIB/bash.sh" "ubuntu@$SLAVE_IP" << END_OF_XSCORE_BUILD_SCRIPT
 set -eux
 
-sudo apt-get -qy update
-sudo apt-get -qy dist-upgrade
-sudo apt-get install -qy git
+sudo tee /etc/apt/apt.conf.d/90-assume-yes << APT_ASSUME_YES
+APT::Get::Assume-Yes "true";
+APT::Get::force-yes "true";
+APT_ASSUME_YES
+
+sudo apt-get update
+sudo apt-get dist-upgrade
+sudo apt-get install git
 
 git clone https://github.com/xapi-project/xenserver-core.git xenserver-core
 


### PR DESCRIPTION
To be able to run the xenserver-core-ubuntu builder job, the system's
apt needs to be configured to be fully automatic. Fixes #26 
