### PR TITLE
Repos are created as clones

### DIFF
--- a/create-github-repo.py
+++ b/create-github-repo.py
@@ -3,33 +3,80 @@ import requests
 import json
 
 
-def create_repo(username, password, org, repo):
-    gurl = 'https://api.github.com'
-    getrepo = gurl + '/repos/%s/%s' % (org, repo)
-    createrepo = gurl + '/orgs/%s/repos' % org
+DST_ORG = "citrix-openstack-build"
+GURL = 'https://api.github.com'
+GETREPO = GURL + '/repos/%s/%s'
+FORKREPO = GURL + '/repos/%s/%s/forks'
+
+
+class Repo(object):
+    def __init__(self, provider, org, name):
+        self.org = org
+        self.name = name
+        self.provider = provider
+
+    def __str__(self):
+        return "Repository %s %s %s" % (self.provider, self.org, self.name)
+
+
+def create_repo_from_line(repoline):
+    varname, org, repo, provider = repoline.strip().split(' ')
+    assert repo.endswith('.git')
+    return Repo(provider, org, repo[:-len('.git')])
+
+
+def status_is_ok(status):
+    return status >= 200 and status < 300
+
+
+def fork_repo(username, password, repo):
     params = dict(auth=(username, password))
 
-    r = requests.get(getrepo, **params)
+    r = requests.post(FORKREPO % (repo.org, repo.name), **params)
+    assert status_is_ok(r.status_code)
 
-    if 404 == r.status_code:
-        print "creating repo..."
-        requests.post(createrepo, data=
-            json.dumps({
-                'name': repo,
-                'team_id': 122958,
-            }), **params)
-        r = requests.get(getrepo, **params)
-        assert 200 == r.status_code
-        print "repo created"
-    else:
-        print "repo exists"
+
+def repo_missing(username, password, repo):
+    params = dict(auth=(username, password))
+
+    r = requests.get(GETREPO % (repo.org, repo.name), **params)
+    if r.status_code == 404:
+        return True
+    assert status_is_ok(r.status_code)
+
+
+def deal_with_repos(username, password, repos):
+    print "Checking that all repos exist"
+    missing = []
+    total = 0
+    for repo_record in repos:
+        total += 1
+        if repo_missing(username, password, repo_record):
+            missing.append(repo_record)
+
+    if len(missing):
+        print "Some repos are missing:"
+        for repo in missing:
+            print " ", repo
+        return 1
+
+    print "OK"
+
+    for src_repo in repos:
+        dst_repo = Repo('github', DST_ORG, src_repo.name)
+        if repo_missing(username, password, dst_repo):
+            print dst_repo, "does not exist, forking", src_repo
+            fork_repo(username, password, src_repo)
+
+    print "OK"
+
+    return 0
 
 
 def main():
-    username, password, org, repo = sys.argv[1:]
-    assert repo.endswith('.git')
-    repo = repo[:-len('.git')]
-    create_repo(username, password, org, repo)
+    username, password = sys.argv[1:]
+    repo_records = [create_repo_from_line(line) for line in sys.stdin.readlines()]
+    sys.exit(deal_with_repos(username, password, repo_records))
 
 
 if __name__ == "__main__":

--- a/create-repos.sh
+++ b/create-repos.sh
@@ -14,10 +14,5 @@ assert_no_new_repos
     set -eu
     mkdir -p .workspace
     cd .workspace
-    generate_repos | while read repo; do
-        repo_to_be_created=$(repo_name "$repo")
-        [ -n "$repo_to_be_created" ]
-        echo "Dealing with $repo_to_be_created"
-        python "$THISDIR/create-github-repo.py" "$USERNAME" "$PASSWORD" "citrix-openstack" "build-$repo_to_be_created"
-    done
+    generate_repos | python "$THISDIR/create-github-repo.py" "$USERNAME" "$PASSWORD"
 )

--- a/delete-build-repos.py
+++ b/delete-build-repos.py
@@ -1,0 +1,23 @@
+import requests
+import json
+import sys
+
+
+username, password = sys.argv[1:]
+
+repoz = []
+resp = requests.get('https://api.github.com/orgs/citrix-openstack/repos')
+repoz += json.loads(resp.text)
+
+link_header = resp.headers['link']
+for link in link_header.split(','):
+    if link.endswith('rel="next"'):
+        url = link.split('>')[0][1:]
+        resp = requests.get(url)
+        repoz += json.loads(resp.text)
+
+
+for repo in repoz:
+    if repo['name'].startswith('build-'):
+        print repo['name'], repo['url']
+        requests.delete(repo['url'], auth=(username, password))

--- a/lib/functions
+++ b/lib/functions
@@ -28,7 +28,7 @@ function generate_repos() {
             echo "DEVSTACK_REPO openstack-dev devstack.git"
         } | extract_var_user_repo | sed 's/$/ github/'
         non_git_repos | extract_var_user_repo | sed 's/$/ anongit/'
-    } | sort
+    } | sort | sed -e '/^BM_IMAGE_BUILD_REPO.*$/d'
 }
 
 function assert_no_new_repos() {
@@ -36,7 +36,6 @@ diff -u \
     <(generate_repos) \
     - \
     << EOF
-BM_IMAGE_BUILD_REPO stackforge diskimage-builder.git github
 BM_POSEUR_REPO tripleo bm_poseur.git github
 CEILOMETERCLIENT_REPO openstack python-ceilometerclient.git github
 CEILOMETER_REPO openstack ceilometer.git github
@@ -93,7 +92,7 @@ function public_repo() {
 
     reponame=$(echo "$repo" | cut -d" " -f 3)
 
-    echo "git@github.com:citrix-openstack/build-$reponame"
+    echo "git@github.com:citrix-openstack-build/$reponame"
 }
 
 function source_repo() {
@@ -183,9 +182,12 @@ function add_public_remote() {
         varname=$(var_name "$repo")
         (
             cd "$varname"
-            if ! git remote -v | grep -q "^public"; then
-                git remote add public $(public_repo "$repo")
+            if git remote -v | grep -q "^public"; then
+                echo "Removed public remote"
+                git remote rm public
             fi
+            echo "Add public remote"
+            git remote add public $(public_repo "$repo")
         )
     done
 }


### PR DESCRIPTION
- Non-accessible repos (BM_IMAGE_BUILD_REPO) were removed.
- Script to delete old build-\* repositories
- Script to fork repositories
- workspace setup script is re-adding the public remote
