### PR TITLE
full tempest - use nosetests

### DIFF
--- a/install-devstack-xen.sh
+++ b/install-devstack-xen.sh
@@ -465,7 +465,7 @@ cd /opt/stack/tempest
 if [ "$TEST_TYPE" == "smoke" ]; then
     ./run_tests.sh -s -N
 elif [ "$TEST_TYPE" == "full" ]; then
-    ./run_tests.sh -N
+    nosetests -sv tempest/api tempest/scenario tempest/thirdparty tempest/cli
 fi
 
 END_OF_DEVSTACK_COMMANDS


### PR DESCRIPTION
We tried to use run_tests.sh to run the full suite, but it seems that
the SkipTest exceptions are not recognised by testr. Switch back to
nosetests for now.
