### PR TITLE
xenserver-core-ubuntu: Work around ocaml-libvirt build problem

### DIFF
--- a/jenkins/jobs/build-xenserver-core-ubuntu.sh
+++ b/jenkins/jobs/build-xenserver-core-ubuntu.sh
@@ -35,7 +35,7 @@ APT_ASSUME_YES
 
 sudo apt-get update
 sudo apt-get dist-upgrade
-sudo apt-get install git
+sudo apt-get install git ocaml-nox
 
 git clone https://github.com/xapi-project/xenserver-core.git -b master xenserver-core
 


### PR DESCRIPTION
makedeb.py expands the spec file %build recipe on the host,
not in a chroot.   The opt target in the %build recipe of some
spec files, such as ocaml-libvirt, is conditional on the existence
of %{_bindir}/ocamlopt.   If ocaml isn't installed on the host,
the opt target won't be included, even though ocamlopt is available
in the chroot.

Installing ocaml on the build host is a quick workaround;  the proper
fix is either to override the check for %{_bindir}/ocamlopt in the
spec file (harder than you might think to do this neatly) or to
run makedeb in the chroot (slow, but accurate).

Signed-off-by: Euan Harris euan.harris@citrix.com
