### PR TITLE
Use bridge names for neutron builds

### DIFF
--- a/generate-citrix-job.sh
+++ b/generate-citrix-job.sh
@@ -51,8 +51,12 @@ function testing_trunk() {
     echo "$BRANCH_REF_NAME" | grep -q "os-trunk-test"
 }
 
+function neutron_setup() {
+    [ "$SETUP_TYPE" = "neutron" ]
+}
+
 # Set FLAT_NETWORK_BRIDGE, but only if we are not testing trunk
-if ! testing_trunk; then
+if ! testing_trunk && ! neutron_setup ; then
     echo "FLAT_NETWORK_BRIDGE=osvmnet" >> $EXTENSIONS
 fi
 


### PR DESCRIPTION
As neutron does not recognise the network name-label, we need to pass
the bridge name. This means, that we need to skip the specification of
FLAT_NETWORK_BRIDGE.

This way, the bridge name will be passed to domU.
