### PR TITLE
Revert "build-xenserver-core: makemake.py is now called by the Makefile"

### DIFF
--- a/jenkins/jobs/build-xenserver-core-centos.sh
+++ b/jenkins/jobs/build-xenserver-core-centos.sh
@@ -55,6 +55,7 @@ git checkout $COMMIT
 git log -1 --pretty=format:%H
 
 ./configure.sh
+./makemake.py > Makefile
 make
 EOF_BUILD_SCRIPT
 su - mock -c "bash /home/mock/build.sh"

--- a/jenkins/jobs/build-xenserver-core-ubuntu.sh
+++ b/jenkins/jobs/build-xenserver-core-ubuntu.sh
@@ -55,5 +55,6 @@ export http_proxy=http://gold.eng.hq.xensource.com:8000
 EOF
 
 sudo ./configure.sh
+./makemake.py > Makefile
 sudo make
 END_OF_XSCORE_BUILD_SCRIPT


### PR DESCRIPTION
This reverts commit 927abc0039bb6f50f6d3f23d37ca5278b4b764a0.

Signed-off-by: Euan Harris euan.harris@citrix.com
