### PR TITLE
Fix plugin suppack name

### DIFF
--- a/jenkins/jobs/builds/build-nova-suppack.sh
+++ b/jenkins/jobs/builds/build-nova-suppack.sh
@@ -69,7 +69,7 @@ xs = Requires(originator='xs', name='main', test='ge',
                product=options.product_name, version='5.6.100',
                build='39265p')
 
-setup(originator='xs', name='openstack-nova', product=options.product_name,
+setup(originator='xs', name='novaplugins', product=options.product_name,
       version=options.product_version, build=options.build, vendor='Citrix Systems, Inc.',
       description="OpenStack Nova Plugins", packages=args, requires=[xs],
       outdir=options.outdir, output=['iso'])


### PR DESCRIPTION
As the rest of the scripts are demanding the suppack to be available as
`novaplugins.iso` - the suppack generation script had to be fixed.
