### PR TITLE
XVA -  generate a new ssh key for each build

### DIFF
--- a/jenkins/jobs/builds/build-nova-suppack.sh
+++ b/jenkins/jobs/builds/build-nova-suppack.sh
@@ -38,6 +38,7 @@ cd ..
 cp -r xenserver-nova-suppack-builder/plugins/* nova/plugins/
 
 cd nova/plugins/xenserver/xenapi/contrib
+./inject-key.sh ~/domzero_public_key
 ./build-rpm.sh
 cd
 


### PR DESCRIPTION
As devstack requires a domzero user to be installed and be able to
authenticate to domain0, the xva needed modifications:
- domzero's key is re-generated
- the public key is injected to the nova suppack
