### PR TITLE
Openstack: CA-188045-Devstack consoles not working

### DIFF
--- a/install-devstack-xen.sh
+++ b/install-devstack-xen.sh
@@ -487,7 +487,7 @@ MULTI_HOST=1
 # See https://bugs.launchpad.net/openstack-ci/+bug/1263824 for euca and bundle
 SKIP_EXERCISES="boot_from_volume,bundle,euca"
 
-ENABLED_SERVICES=g-api,g-reg,key,n-api,n-crt,n-obj,n-cpu,n-sch,horizon,mysql,rabbit,sysstat,tempest,s-proxy,s-account,s-container,s-object,cinder,c-api,c-vol,c-sch,n-cond,heat,h-api,h-api-cfn,h-api-cw,h-eng,n-net
+ENABLED_SERVICES=g-api,g-reg,key,n-api,n-crt,n-obj,n-cpu,n-sch,horizon,mysql,rabbit,sysstat,tempest,s-proxy,s-account,s-container,s-object,cinder,c-api,c-vol,c-sch,n-cond,heat,h-api,h-api-cfn,h-api-cw,h-eng,n-net,n-novnc,n-cauth
 
 # XEN_FIREWALL_DRIVER=nova.virt.xenapi.firewall.Dom0IptablesFirewallDriver
 XEN_FIREWALL_DRIVER=nova.virt.firewall.NoopFirewallDriver


### PR DESCRIPTION
Need enable additional services in order to support console access
to guest VMs.