### PR TITLE
Add enable_plugin in localrc

### DIFF
--- a/install-devstack-xen.sh
+++ b/install-devstack-xen.sh
@@ -433,6 +433,8 @@ cat << LOCALCONF_CONTENT_ENDS_HERE > local.conf
 # --------------------------------
 [[local|localrc]]
 
+enable_plugin os-xenapi https://github.com/openstack/os-xenapi.git
+
 # Passwords
 MYSQL_PASSWORD=citrix
 SERVICE_TOKEN=citrix


### PR DESCRIPTION
Our devstack patch for using os-xenapi as devstack plugins has been
merged to upstream, we must provide such configurations in localrc
or local.conf