### PR TITLE
Give a default value before there is a progress value.

### DIFF
--- a/fuel_test/deploy_env.sh
+++ b/fuel_test/deploy_env.sh
@@ -234,7 +234,7 @@ function verify_network {
 			echo 1
 			return
 		fi
-		if [ "$progress" -eq "100" ]; then
+		if [ "${progress:-0}" -eq "100" ]; then
 			echo 0
 			return
 		fi


### PR DESCRIPTION

Resolve the following error:

04:29:32 +++ '[' '' -eq 100 ']'
04:29:32 ./deploy_env.sh: line 237: [: : integer expression expected

the progress value may be populated at the beginning, so if it's empty, let's give a default value as 0.