### PR TITLE
Configure local.conf to avoid ssh timeout problem

### DIFF
--- a/install-devstack-xen.sh
+++ b/install-devstack-xen.sh
@@ -494,16 +494,24 @@ NETWORK_GATEWAY=192.168.10.1
 VLAN_INTERFACE=eth1
 PUBLIC_INTERFACE=eth2
 
+# TODO(huanxie): change this when upgrade to new version
+CIRROS_VERSION=0.3.4
+
 # Nova user specific configuration
 # --------------------------------
 [[post-config|\\\$NOVA_CONF]]
 [DEFAULT]
 disk_allocation_ratio = 2.0
+host = Dom0_DevStackOS
 
 # Neutron ovs bridge mapping
 [[post-config|\\\$NEUTRON_CORE_PLUGIN_CONF]]
 [ovs]
 bridge_mappings = physnet1:br-eth1,public:br-ex
+
+[[post-config|\\\$NEUTRON_CORE_PLUGIN_CONF.domU]]
+[DEFAULT]
+host = Dom0_DevStackOS
 
 LOCALCONF_CONTENT_ENDS_HERE
 


### PR DESCRIPTION
1. With XenServer, we have two ovs agent running in DomU in the aio
devstack environment, I have a patch to fix it in xenapi-os-testing
see https://review.openstack.org/#/c/376287/, this patch is to do
the same thing in our wrapped install-devstack-xen.sh script.
2. cirros has changed the version from 0.3.4 to 0.3.5 in devstack,
but we don't have 0.3.5 cirros ATM, I have made a patch to avoid
this problem in our external Neutron CI, see
https://review.openstack.org/#/c/434659/, backport this fix here