### PR TITLE
Fuel_Test: Download gpg keyfile before build supplemental pack

### DIFF
--- a/fuel_test/deploy_env.sh
+++ b/fuel_test/deploy_env.sh
@@ -51,6 +51,7 @@ pip install git+https://github.com/openstack/fuel-plugins
 		'
 set -ex
 cd /root/fuel-plugin-xenserver
+wget "'$GPG_KEYFILE_URL'" -O /root/fuel-plugin-xenserver/suppack/RPM-GPG-KEY-XS-OPENSTACK
 fpb --check .
 fpb --build .
 mkdir -p output

--- a/fuel_test/localrc.default
+++ b/fuel_test/localrc.default
@@ -5,6 +5,7 @@ export FM_PWD=${FM_PWD:-""}
 export IXE_NFS=${IXE_NFS:-""}
 export IXE_ISO=${IXE_ISO:-""}
 export GPG_SECRET_KEY_URL=${GPG_SECRET_KEY_URL:-""}
+export GPG_KEYFILE_URL=${GPG_KEYFILE_URL:-""}
 export FUEL_TEST_SUCCESS=${FUEL_TEST_SUCCESS:-"/opt/success_fuel_test"}
 export FUEL_TEST_LOG_DIR=${FUEL_TEST_LOG_DIR:-"fuel_test_logs"}
 export FM_SNAPSHOT="fuel_ci"


### PR DESCRIPTION
For building supplemental packages and install it in Ely and later,
we should specify the keyfile, so this patch it to download gpg
keyfile in advance