### PR TITLE
Fuel: Remove MOS9 excluded heat health check

### DIFF
--- a/fuel_test/localrc.default
+++ b/fuel_test/localrc.default
@@ -40,7 +40,7 @@ export DEBUG=on
 
 export -A IGNORE_CHECKS
 IGNORE_CHECKS[8]=""
-IGNORE_CHECKS[9]="Update stack actions: inplace, replace and update whole template"
+IGNORE_CHECKS[9]=""
 
 export -A REL_NAME
 REL_NAME[8]="Liberty on Ubuntu 14.04"


### PR DESCRIPTION
With MOS9.2, we have patched the VIF hot plug/unplug patch, so
"Update stack actions: inplace, replace and update whole template"
heat health check should pass