### PR TITLE
Create tempest exclusion lit for multiple nodes tests.

### DIFF
--- a/tempest/tempest_exclusion_list
+++ b/tempest/tempest_exclusion_list
@@ -1,0 +1,38 @@
+COMMON_TEMPEST_REGEX="(?!.*\[.*\bslow\b.*\]"
+
+# Exclude device tagging on stable/ocata
+if [ "$ZUUL_BRANCH" = "stable/ocata" ]; then
+    COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.api.compute.servers.test_device_tagging.*"
+fi
+
+# Exclude encrypted volume tests which will create HVM VM which is not supported in nest virt env.
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_boot_server_from_encrypted_volume_luks"
+# Exclude some glance tests before fix the CI broken by coalesce performance
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.api.compute.images.test_list_image_filters.ListImageFiltersTestJSON.*"
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_create_backup.*"
+# Exclude volume backup and upload tests to avoid heavy disk IO.
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.api.volume.*test_volumes_backup.*"
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.api.volume.test_volumes_actions.*test_volume_upload.*"
+# Exclude these tests failing randomly. Need fix the potential race conditions.
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.api.compute.admin.test_hosts_negative.HostsAdminNegativeTestJSON.test_startup_host_with_non_admin_user"
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.api.volume.test_volume_delete_cascade.VolumesDeleteCascade.test_volume_from_snapshot_cascade_delete"
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_create_ebs_image_and_check_boot"
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.api.volume.test_volumes_snapshots.VolumesSnapshotTestJSON.test_volume_from_snapshot"
+# Exclude server diagnostics tests. Need figure out why it's frequently failed.
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.api.compute.admin.test_server_diagnostics.*"
+
+# Need resolve the timeout issue when access from floating IP, root cause is VM will hang while bootloading when concurrently boot many VMs with volume.
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON.test_rebuild_server_with_volume_attached.*"
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.scenario.test_shelve_instance.TestShelveInstance.test_shelve_volume_backed_instance.*"
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.scenario.test_volume_boot_pattern.TestVolumeBootPattern.test_volume_boot_pattern.*"
+COMMON_TEMPEST_REGEX="$COMMON_TEMPEST_REGEX|.*tempest.scenario.test_volume_boot_pattern.TestVolumeBootPatternV2.test_volume_boot_pattern.*"
+
+
+# Add exclusion list for tests in multiple nodes.
+
+# Exclude these tests before fixing this bug: https://bugs.launchpad.net/nova/+bug/1704071
+MULTI_NODES_TEMPEST_REGEX="MULTI_NODES_TEMPEST_REGEX|.*tempest.api.compute.admin.test_live_migration.LiveAutoBlockMigrationV225Test.*"
+MULTI_NODES_TEMPEST_REGEX="MULTI_NODES_TEMPEST_REGEX|.*tempest.api.compute.admin.test_live_migration.LiveMigrationRemoteConsolesV26Test.*"
+MULTI_NODES_TEMPEST_REGEX="MULTI_NODES_TEMPEST_REGEX|.*tempest.api.compute.admin.test_live_migration.LiveMigrationTest.*"
+
+MULTI_NODES_TEMPEST_REGEX="MULTI_NODES_TEMPEST_REGEX)(^tempest\.(api|scenario|thirdparty))"


### PR DESCRIPTION
The common exclusion list is copied from:
https://raw.githubusercontent.com/openstack/xenapi-os-testing/master/tempest_exclusion_list

Adding some tests which are known having issues on multiple nodes.

This exclusion list will be used for XenRT tests to run full tempest test on multiple devstack nodes.